### PR TITLE
Update postgresql package to use binary version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-psycopg2==2.9.1
+psycopg2-binary==2.9.1


### PR DESCRIPTION
Using `psycopg2-binary` instead of `psycopg2` to resolve an issue with Lambda failing with the following message:
```
libpq.so.5: cannot open shared object file: No such file or directory
```